### PR TITLE
Config prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARCH := $(shell case $$(uname -m) in (x86_64) echo amd64 ;; (aarch64) echo arm64
 
 BIN_DIR := ./.bin
 
-TINYGO_VERSION := 0.26.0
+TINYGO_VERSION := 0.30.0
 TINYGO := $(abspath $(BIN_DIR)/tinygo-$(TINYGO_VERSION))/bin/tinygo
 
 DOCKER_NETWORK := proxy-wasm-http-header-rename_default
@@ -31,7 +31,7 @@ test-docker:
 		--volume "$(shell pwd):/workspace" \
 		--workdir /workspace \
 		--network $(DOCKER_NETWORK) \
-		golang:1.19.5-bullseye make test
+		golang:1.22.0-bullseye make test
 
 .PHONY: build
 build: $(TINYGO)
@@ -45,5 +45,5 @@ build-docker:
 		--volume "$(shell pwd):/workspace" \
 		--user "$(shell id -u):$(shell id -g)" \
 		--workdir /workspace \
-		golang:1.19.5-bullseye \
+		golang:1.21.7-bullseye \
 		make build

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   envoy:
-    image: envoyproxy/envoy:v1.24.1
+    image: envoyproxy/envoy:v1.29.1
     ports:
       - ${PORT-8080}:8080
     volumes:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kauche/proxy-wasm-http-header-rename
 
-go 1.19
+go 1.21
 
 require (
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tetratelabs/proxy-wasm-go-sdk v0.20.0 h1:i/xtxt/jHXtp/yImhlp4pAWx0eVzIBKOaay3Nu4Iw3k=
 github.com/tetratelabs/proxy-wasm-go-sdk v0.20.0/go.mod h1:7uUubjgZpmccNAPqSS6Il6CF+tk3BGf4qSCJZp3W8s8=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
@@ -10,3 +13,4 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config.go
+++ b/internal/config.go
@@ -5,6 +5,7 @@ const (
 	configKeyHeader                 = "header"
 	configKeyKey                    = "key"
 	configKeyValue                  = "value"
+	configKeyPrefix                 = "prefix"
 )
 
 type pluginConfiguration struct {
@@ -16,6 +17,7 @@ type requestHeaderToRename struct {
 }
 
 type headerValue struct {
-	key   string
-	value string
+	key    string
+	value  string
+	prefix string
 }

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -75,10 +75,13 @@ func getPluginConfiguration() (*pluginConfiguration, error) {
 			return nil, errors.New("the header value for renaming is empty")
 		}
 
+		prefix := h.Get(configKeyPrefix).String()
+
 		headersToRename[i] = requestHeaderToRename{
 			header: headerValue{
-				key:   key,
-				value: value,
+				key:    key,
+				value:  value,
+				prefix: prefix,
 			},
 		}
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -24,6 +24,7 @@ func TestE2E(t *testing.T) {
 
 	req.Header.Set("original-header-1", "original-header-value-1")
 	req.Header.Set("original-header-2", "original-header-value-2")
+	req.Header.Set("original-header-3", "original-header-value-3")
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -80,6 +81,20 @@ func TestE2E(t *testing.T) {
 	_, ok = echores.Headers["original-header-2"]
 	if ok {
 		t.Error("original-header-2 header should be removed")
+		return
+	}
+
+	newHeader3, ok := echores.Headers["new-header-3"]
+	if !ok {
+		t.Error("new-header-3 header is not found")
+		return
+	}
+	if len(newHeader3.Value) != 1 {
+		t.Errorf("new-header-3 header has invalid number of values: %d", len(newHeader3.Value))
+		return
+	}
+	if newHeader3.Value[0] != "bearer original-header-value-3" {
+		t.Errorf("the value for new-header-3 is expected to be `bearer original-header-value3`, but got `%s`", newHeader3.Value[0])
 		return
 	}
 }

--- a/test/envoy.yaml
+++ b/test/envoy.yaml
@@ -58,6 +58,13 @@ static_resources:
                                       "key": "original-header-2",
                                       "value": "new-header-2"
                                     }
+                                  },
+                                  {
+                                    "header": {
+                                      "key": "original-header-3",
+                                      "value": "new-header-3",
+                                      "prefix": "bearer "
+                                    }
                                   }
                                 ]
                               }


### PR DESCRIPTION
- feat: Add `prefix` to the config that enables us add a header value prefix (e.g. `bearer`) for the new header.
- chore: update tools (go, tinygo, envoy)